### PR TITLE
Add ChatUtils and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This sample plugin demonstrates some of the basic functionality the plugin API c
 - Adds a plugin setting tab to the settings page.
 - Registers a global click event and output 'click' to the console.
 - Registers a global interval which logs 'setInterval' to the console.
+- Includes chat utilities for saving transcripts as notes.
 
 ## First time developing plugins?
 

--- a/src/ChatUtils.ts
+++ b/src/ChatUtils.ts
@@ -13,15 +13,21 @@ export class ChatUtils {
         await FileHelper.createFolderIfNotExists(normalizePath(folder), vault);
 
         if (templater.isAvailable) {
-            const file = await templater.createFromTemplate(
-                content,
-                folder,
-                filename,
-                {},
-                false
-            );
-            if (file) {
-                return file;
+            try {
+                const file = await templater.createFromTemplate(
+                    content,
+                    folder,
+                    filename,
+                    {},
+                    false
+                );
+                if (file) {
+                    return file;
+                } else {
+                    console.error(`Failed to create file from template: Returned file is falsy. Folder: ${folder}, Filename: ${filename}`);
+                }
+            } catch (error) {
+                console.error(`Error while creating file from template. Folder: ${folder}, Filename: ${filename}`, error);
             }
         }
 

--- a/src/ChatUtils.ts
+++ b/src/ChatUtils.ts
@@ -1,0 +1,31 @@
+import { TFile, Vault, normalizePath } from "obsidian";
+import { FileHelper } from "./FileHelper";
+import { TemplaterHelper } from "./TemplaterHelper";
+
+export class ChatUtils {
+    static async saveTranscript(
+        vault: Vault,
+        templater: TemplaterHelper,
+        folder: string,
+        filename: string,
+        content: string
+    ): Promise<TFile> {
+        await FileHelper.createFolderIfNotExists(normalizePath(folder), vault);
+
+        if (templater.isAvailable) {
+            const file = await templater.createFromTemplate(
+                content,
+                folder,
+                filename,
+                {},
+                false
+            );
+            if (file) {
+                return file;
+            }
+        }
+
+        const path = normalizePath(`${folder}/${filename}`);
+        return vault.create(path, content);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ChatUtils.saveTranscript` with Templater fallback
- mention chat utilities in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68836e447104832fb3bc4df52bcb0849